### PR TITLE
Group roads into major/minor export layers, update UI and colors

### DIFF
--- a/map-exporter/index.html
+++ b/map-exporter/index.html
@@ -197,87 +197,33 @@
                 <div class="mb-3">
                     <div class="form-text mb-2">Include and color</div>
 
-                    <!-- Highways, split by class -->
+                    <!-- Roads, grouped into major/minor export layers -->
                     <div class="border rounded p-2 mb-2">
-                        <div class="small text-muted mb-2">Road classes</div>
+                        <div class="small text-muted mb-2">Road export layers</div>
 
                         <div class="row g-2 align-items-center mb-2">
                             <div class="col-7">
                                 <div class="form-check">
-                                    <input class="form-check-input" type="checkbox" id="chkMotorway" checked>
-                                    <label class="form-check-label" for="chkMotorway">motorway</label>
+                                    <input class="form-check-input" type="checkbox" id="chkMajorRoads" checked>
+                                    <label class="form-check-label" for="chkMajorRoads">major roads (motorway, trunk, primary)</label>
                                 </div>
                             </div>
                             <div class="col-5 text-end">
-                                <!-- default red -->
-                                <input id="colMotorway" class="form-control form-control-color color" type="color"
-                                       value="#ff0000" title="Motorway color">
+                                <input id="colMajorRoads" class="form-control form-control-color color" type="color"
+                                       value="#ff8c00" title="Major roads color">
                             </div>
                         </div>
 
                         <div class="row g-2 align-items-center mb-2">
                             <div class="col-7">
                                 <div class="form-check">
-                                    <input class="form-check-input" type="checkbox" id="chkTrunk" checked>
-                                    <label class="form-check-label" for="chkTrunk">trunk</label>
+                                    <input class="form-check-input" type="checkbox" id="chkMinorRoads" checked>
+                                    <label class="form-check-label" for="chkMinorRoads">minor roads (secondary, tertiary, local)</label>
                                 </div>
                             </div>
                             <div class="col-5 text-end">
-                                <input id="colTrunk" class="form-control form-control-color color" type="color"
-                                       value="#ff7f00" title="Trunk color">
-                            </div>
-                        </div>
-
-                        <div class="row g-2 align-items-center mb-2">
-                            <div class="col-7">
-                                <div class="form-check">
-                                    <input class="form-check-input" type="checkbox" id="chkPrimary" checked>
-                                    <label class="form-check-label" for="chkPrimary">primary</label>
-                                </div>
-                            </div>
-                            <div class="col-5 text-end">
-                                <input id="colPrimary" class="form-control form-control-color color" type="color"
-                                       value="#ffd000" title="Primary color">
-                            </div>
-                        </div>
-
-                        <div class="row g-2 align-items-center mb-2">
-                            <div class="col-7">
-                                <div class="form-check">
-                                    <input class="form-check-input" type="checkbox" id="chkSecondary" checked>
-                                    <label class="form-check-label" for="chkSecondary">secondary</label>
-                                </div>
-                            </div>
-                            <div class="col-5 text-end">
-                                <input id="colSecondary" class="form-control form-control-color color" type="color"
-                                       value="#999999" title="Secondary color">
-                            </div>
-                        </div>
-
-                        <div class="row g-2 align-items-center mb-2">
-                            <div class="col-7">
-                                <div class="form-check">
-                                    <input class="form-check-input" type="checkbox" id="chkTertiary" checked>
-                                    <label class="form-check-label" for="chkTertiary">tertiary</label>
-                                </div>
-                            </div>
-                            <div class="col-5 text-end">
-                                <input id="colTertiary" class="form-control form-control-color color" type="color"
-                                       value="#bbbbbb" title="Tertiary color">
-                            </div>
-                        </div>
-
-                        <div class="row g-2 align-items-center">
-                            <div class="col-7">
-                                <div class="form-check">
-                                    <input class="form-check-input" type="checkbox" id="chkLocal" checked>
-                                    <label class="form-check-label" for="chkLocal">local (residential, unclassified,
-                                        service, living_street)</label>
-                                </div>
-                            </div>
-                            <div class="col-5 text-end">
-                                <input id="colLocal" class="form-control form-control-color color" type="color"
-                                       value="#333333" title="Local roads color">
+                                <input id="colMinorRoads" class="form-control form-control-color color" type="color"
+                                       value="#000000" title="Minor roads color">
                             </div>
                         </div>
                     </div>
@@ -294,7 +240,7 @@
                             <input id="colBuildings"
                                    class="form-control form-control-color color"
                                    type="color"
-                                   value="#bbbbbb"
+                                   value="#ff2d2d"
                                    title="Buildings color">
                         </div>
                     </div>

--- a/map-exporter/js/main.js
+++ b/map-exporter/js/main.js
@@ -35,26 +35,18 @@ function getSelections() {
     width: Math.max(512, (+document.getElementById('w').value | 0) || 4096),
     height: Math.max(512, (+document.getElementById('h').value | 0) || 4096),
     want: {
-      motorway: document.getElementById('chkMotorway').checked,
-      trunk: document.getElementById('chkTrunk').checked,
-      primary: document.getElementById('chkPrimary').checked,
-      secondary: document.getElementById('chkSecondary').checked,
-      tertiary: document.getElementById('chkTertiary').checked,
-      local: document.getElementById('chkLocal').checked,
+      majorRoads: document.getElementById('chkMajorRoads').checked,
+      minorRoads: document.getElementById('chkMinorRoads').checked,
       water: document.getElementById('chkWater').checked,
       parks: document.getElementById('chkParks').checked,
       buildings: document.getElementById('chkBuildings').checked
     },
     colors: {
-      motorway: document.getElementById('colMotorway').value || '#dd00ff',
-      trunk: document.getElementById('colTrunk').value || '#ff7f00',
-      primary: document.getElementById('colPrimary').value || '#ffd000',
-      secondary: document.getElementById('colSecondary').value || '#00ffcf',
-      tertiary: document.getElementById('colTertiary').value || '#bbbbbb',
-      local: document.getElementById('colLocal').value || '#333333',
+      majorRoads: document.getElementById('colMajorRoads').value || '#ff8c00',
+      minorRoads: document.getElementById('colMinorRoads').value || '#000000',
       water: document.getElementById('colWater').value || '#4b64e1',
       parks: document.getElementById('colParks').value || '#00ff32',
-      buildings: document.getElementById('colBuildings').value || '#fd0000'
+      buildings: document.getElementById('colBuildings').value || '#ff2d2d'
     }
   };
 }

--- a/map-exporter/js/overpass.js
+++ b/map-exporter/js/overpass.js
@@ -43,12 +43,8 @@ export function buildOverpassBBox(b, want) {
   }
 
   const roadClasses = [];
-  if (want.motorway) roadClasses.push('motorway');
-  if (want.trunk) roadClasses.push('trunk');
-  if (want.primary) roadClasses.push('primary');
-  if (want.secondary) roadClasses.push('secondary');
-  if (want.tertiary) roadClasses.push('tertiary');
-  if (want.local) roadClasses.push('residential', 'unclassified', 'service', 'living_street');
+  if (want.majorRoads) roadClasses.push('motorway', 'trunk', 'primary');
+  if (want.minorRoads) roadClasses.push('secondary', 'tertiary', 'residential', 'unclassified', 'service', 'living_street');
 
   if (roadClasses.length) {
     const roadRegex = `^(${Array.from(new Set(roadClasses)).join('|')})$`;

--- a/map-exporter/js/svg.js
+++ b/map-exporter/js/svg.js
@@ -107,12 +107,8 @@ export function buildSVG({ width, height, bbox, elements, want, colors, clipToFr
   const gParks = group(); gParks.setAttribute('id', 'parks');
   const gWater = group(); gWater.setAttribute('id', 'water');
   const gBldg = group(); gBldg.setAttribute('id', 'buildings');
-  const gMotor = group(); gMotor.setAttribute('id', 'motorway');
-  const gTrunk = group(); gTrunk.setAttribute('id', 'trunk');
-  const gPrim = group(); gPrim.setAttribute('id', 'primary');
-  const gSec = group(); gSec.setAttribute('id', 'secondary');
-  const gTert = group(); gTert.setAttribute('id', 'tertiary');
-  const gLocal = group(); gLocal.setAttribute('id', 'local');
+  const gMajorRoads = group(); gMajorRoads.setAttribute('id', 'major_roads');
+  const gMinorRoads = group(); gMinorRoads.setAttribute('id', 'minor_roads');
 
   const parks = want.parks ? elements.filter((e) => predicates.isPark(e.tags)) : [];
   const watersP = want.water ? elements.filter((e) => predicates.isWaterPolygon(e.tags)) : [];
@@ -120,12 +116,20 @@ export function buildSVG({ width, height, bbox, elements, want, colors, clipToFr
   const buildings = want.buildings ? elements.filter((e) => predicates.isBuilding(e.tags)) : [];
 
   const ways = elements.filter((e) => e.type === 'way' && e.geometry && e.geometry.length >= 2);
-  const mtr = want.motorway ? ways.filter((e) => predicates.highwayEq(e.tags, 'motorway')) : [];
-  const trk = want.trunk ? ways.filter((e) => predicates.highwayEq(e.tags, 'trunk')) : [];
-  const pry = want.primary ? ways.filter((e) => predicates.highwayEq(e.tags, 'primary')) : [];
-  const sec = want.secondary ? ways.filter((e) => predicates.highwayEq(e.tags, 'secondary')) : [];
-  const ter = want.tertiary ? ways.filter((e) => predicates.highwayEq(e.tags, 'tertiary')) : [];
-  const loc = want.local ? ways.filter((e) => predicates.isLocalRoad(e.tags)) : [];
+  const majorRoads = want.majorRoads
+    ? ways.filter((e) => (
+      predicates.highwayEq(e.tags, 'motorway')
+      || predicates.highwayEq(e.tags, 'trunk')
+      || predicates.highwayEq(e.tags, 'primary')
+    ))
+    : [];
+  const minorRoads = want.minorRoads
+    ? ways.filter((e) => (
+      predicates.highwayEq(e.tags, 'secondary')
+      || predicates.highwayEq(e.tags, 'tertiary')
+      || predicates.isLocalRoad(e.tags)
+    ))
+    : [];
 
   for (const feat of parks) {
     const p = document.createElementNS(SVG_NS, 'path');
@@ -208,12 +212,8 @@ export function buildSVG({ width, height, bbox, elements, want, colors, clipToFr
   if (want.parks) svg.appendChild(gParks);
   if (want.water) svg.appendChild(gWater);
   if (want.buildings) svg.appendChild(gBldg);
-  if (want.motorway) addLine(mtr, gMotor, colors.motorway, 3.2), svg.appendChild(gMotor);
-  if (want.trunk) addLine(trk, gTrunk, colors.trunk, 3.0), svg.appendChild(gTrunk);
-  if (want.primary) addLine(pry, gPrim, colors.primary, 2.6), svg.appendChild(gPrim);
-  if (want.secondary) addLine(sec, gSec, colors.secondary, 2.2), svg.appendChild(gSec);
-  if (want.tertiary) addLine(ter, gTert, colors.tertiary, 2.0), svg.appendChild(gTert);
-  if (want.local) addLine(loc, gLocal, colors.local, 1.6), svg.appendChild(gLocal);
+  if (want.majorRoads) addLine(majorRoads, gMajorRoads, colors.majorRoads, 2.8), svg.appendChild(gMajorRoads);
+  if (want.minorRoads) addLine(minorRoads, gMinorRoads, colors.minorRoads, 1.9), svg.appendChild(gMinorRoads);
 
   const serializer = new XMLSerializer();
   const svgStr = serializer.serializeToString(svg);


### PR DESCRIPTION
### Motivation
- Simplify road selection by grouping multiple highway classes into `major` and `minor` export layers for easier styling and export.
- Align Overpass queries and SVG rendering with the new grouped selections so exported SVGs reflect the simplified layers.
- Update default colors and UI labels to match the new grouping.

### Description
- Updated the controls in `map-exporter/index.html` to replace individual road class checkboxes/colour pickers with `chkMajorRoads`/`colMajorRoads` and `chkMinorRoads`/`colMinorRoads`, and changed the buildings default color.
- Updated `map-exporter/js/main.js` to collect the new `majorRoads` and `minorRoads` selections and their colors in `getSelections()`.
- Modified `map-exporter/js/overpass.js` to build the Overpass bbox query using grouped road classes (`motorway|trunk|primary` for majors and `secondary|tertiary|residential|unclassified|service|living_street` for minors) and to generate a single regex for `highway` matching.
- Updated `map-exporter/js/svg.js` to create `major_roads` and `minor_roads` SVG groups, select ways that belong to each grouped category, and draw them with adjusted stroke widths and the new color keys.

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0113abb44832aba30e7227b9fa167)