### PR TITLE
Add export progress panel, frame controls, Overpass retry/timeout and cancellable export pipeline

### DIFF
--- a/map-exporter/index.html
+++ b/map-exporter/index.html
@@ -40,6 +40,64 @@
             overflow: auto
         }
 
+        .progress-card {
+            position: absolute;
+            top: 4.25rem;
+            right: 1rem;
+            z-index: 1000;
+            width: min(380px, calc(100vw - 2rem));
+            max-height: calc(88vh - 40px);
+            overflow: auto;
+        }
+
+        .progress-log {
+            font-size: .88rem;
+            max-height: 220px;
+            overflow: auto;
+            background: #f8f9fa;
+            border: 1px solid #e9ecef;
+            border-radius: .35rem;
+            padding: .5rem .65rem;
+            margin-top: .6rem;
+        }
+
+        .progress-log .log-item {
+            display: flex;
+            align-items: flex-start;
+            gap: .5rem;
+            margin-bottom: .4rem;
+            line-height: 1.2;
+        }
+
+        .progress-log .log-item:last-child {
+            margin-bottom: 0;
+        }
+
+        .progress-log .dot {
+            width: .5rem;
+            height: .5rem;
+            margin-top: .25rem;
+            border-radius: 50%;
+            background: #6c757d;
+            flex: 0 0 auto;
+        }
+
+        .progress-log .log-item.done .dot {
+            background: #198754;
+        }
+
+        .progress-log .log-item.error .dot {
+            background: #dc3545;
+        }
+
+        .hint-card {
+            border: 1px solid #e9ecef;
+            border-radius: .35rem;
+            padding: .55rem .65rem;
+            background: #f8f9fa;
+            font-size: .86rem;
+        }
+
         .controls-toggle {
             position: absolute;
             top: 1rem;
@@ -193,6 +251,15 @@
                     <span class="text-muted small ms-auto">Data: OSM via Overpass</span>
                 </div>
 
+                <div class="hint-card mb-3">
+                    <div class="fw-semibold mb-1">Frame details</div>
+                    <div id="frameInfo" class="text-muted mb-2">Frame inactive (using current viewport)</div>
+                    <div class="d-flex gap-2">
+                        <button id="btnSnapFrame" class="btn btn-outline-secondary btn-sm">Snap frame to view</button>
+                        <button id="btnResetFrame" class="btn btn-outline-secondary btn-sm">Reset frame</button>
+                    </div>
+                </div>
+
                 <!-- Options -->
                 <div class="mb-3">
                     <div class="form-text mb-2">Include and color</div>
@@ -284,6 +351,37 @@
                     </div>
                 </div>
 
+                <div id="exportEstimate" class="hint-card mt-3">
+                    <div class="d-flex justify-content-between align-items-center">
+                        <span class="fw-semibold">Export estimate</span>
+                        <span id="estimateBadge" class="badge text-bg-success">Fast</span>
+                    </div>
+                    <div id="estimateText" class="text-muted mt-1">Ready to export.</div>
+                </div>
+
+            </div>
+        </div>
+    </div>
+
+    <div id="exportProgressPanel" class="card progress-card shadow d-none">
+        <div class="card-header py-2 d-flex justify-content-between align-items-center">
+            <div class="h6 mb-0">Export progress</div>
+            <div class="d-flex align-items-center gap-2">
+                <span id="exportProgressElapsed" class="badge text-bg-light">0s</span>
+                <span id="exportProgressPercent" class="badge text-bg-secondary">0%</span>
+            </div>
+        </div>
+        <div class="card-body">
+            <div id="exportProgressStatus" class="small text-muted mb-2">Waiting to export…</div>
+            <div id="exportProgressStage" class="small text-muted mb-2">Stage 0/0</div>
+            <div class="progress" role="progressbar" aria-label="Export progress" aria-valuemin="0" aria-valuemax="100">
+                <div id="exportProgressBar" class="progress-bar progress-bar-striped progress-bar-animated" style="width: 0%">0%</div>
+            </div>
+            <div id="exportProgressLog" class="progress-log"></div>
+            <div id="exportErrorBox" class="alert alert-danger mt-2 py-2 px-3 d-none mb-0" role="alert"></div>
+            <div class="d-flex gap-2 mt-2">
+                <button id="btnCancelExport" class="btn btn-outline-danger btn-sm">Cancel</button>
+                <button id="btnRetryExport" class="btn btn-outline-primary btn-sm d-none">Retry last export</button>
             </div>
         </div>
     </div>

--- a/map-exporter/js/frame.js
+++ b/map-exporter/js/frame.js
@@ -89,6 +89,29 @@ export function initFrameControls(map) {
     drawFrame();
   }
 
+  function setFrameFromBounds(bounds) {
+    const padLng = (bounds.getEast() - bounds.getWest()) * 0.15;
+    const padLat = (bounds.getNorth() - bounds.getSouth()) * 0.15;
+    frame = {
+      nw: [bounds.getWest() + padLng, bounds.getNorth() - padLat],
+      se: [bounds.getEast() - padLng, bounds.getSouth() + padLat]
+    };
+    drawFrame();
+  }
+
+  function snapFrameToViewport() {
+    if (!frame) {
+      addFrame();
+      return;
+    }
+    setFrameFromBounds(map.getBounds());
+  }
+
+  function resetFrame() {
+    if (!frame) return;
+    setFrameFromBounds(map.getBounds());
+  }
+
   function removeFrame() {
     frame = null;
     if (map.getLayer('frame-line')) map.removeLayer('frame-line');
@@ -124,6 +147,22 @@ export function initFrameControls(map) {
     };
   }
 
+  function getFrameInfo() {
+    if (!frame) return null;
+    const west = Math.min(frame.nw[0], frame.se[0]);
+    const east = Math.max(frame.nw[0], frame.se[0]);
+    const south = Math.min(frame.se[1], frame.nw[1]);
+    const north = Math.max(frame.se[1], frame.nw[1]);
+    return {
+      west,
+      east,
+      south,
+      north,
+      widthDeg: east - west,
+      heightDeg: north - south
+    };
+  }
+
   document.getElementById('btnToggleFrame').addEventListener('click', () => {
     if (frame) removeFrame();
     else addFrame();
@@ -135,6 +174,9 @@ export function initFrameControls(map) {
 
   return {
     getActiveBBox,
+    getFrameInfo,
+    resetFrame,
+    snapFrameToViewport,
     isFrameActive: () => !!frame
   };
 }

--- a/map-exporter/js/main.js
+++ b/map-exporter/js/main.js
@@ -73,6 +73,145 @@ function initPreviewExport(map, frameApi) {
   const btnDownloadModal = document.getElementById('btnDownloadModal');
   const pageBusy = document.getElementById('pageBusy');
 
+  const exportProgressPanel = document.getElementById('exportProgressPanel');
+  const exportProgressBar = document.getElementById('exportProgressBar');
+  const exportProgressPercent = document.getElementById('exportProgressPercent');
+  const exportProgressStatus = document.getElementById('exportProgressStatus');
+  const exportProgressStage = document.getElementById('exportProgressStage');
+  const exportProgressElapsed = document.getElementById('exportProgressElapsed');
+  const exportProgressLog = document.getElementById('exportProgressLog');
+  const exportErrorBox = document.getElementById('exportErrorBox');
+  const btnCancelExport = document.getElementById('btnCancelExport');
+  const btnRetryExport = document.getElementById('btnRetryExport');
+
+  const frameInfoEl = document.getElementById('frameInfo');
+  const btnSnapFrame = document.getElementById('btnSnapFrame');
+  const btnResetFrame = document.getElementById('btnResetFrame');
+  const estimateBadge = document.getElementById('estimateBadge');
+  const estimateText = document.getElementById('estimateText');
+
+  const STAGE_TOTAL = 5;
+  let elapsedTimer = null;
+  let exportStartedAt = 0;
+  let stageIndex = 0;
+  let lastLogLine = '';
+  let exportAbortController = null;
+  let isExporting = false;
+  let lastExportRequest = null;
+  const overpassCache = new Map();
+
+  function getElapsedSec() {
+    return Math.floor((Date.now() - exportStartedAt) / 1000);
+  }
+
+  function setProgress(percent, status, opts = {}) {
+    const p = Math.max(0, Math.min(100, Math.round(percent)));
+    const { indeterminate = false } = opts;
+
+    if (indeterminate) {
+      exportProgressBar.classList.add('progress-bar-striped', 'progress-bar-animated');
+      exportProgressBar.style.width = '100%';
+      exportProgressBar.textContent = '…';
+      exportProgressPercent.textContent = '…';
+    } else {
+      exportProgressBar.classList.add('progress-bar-striped', 'progress-bar-animated');
+      exportProgressBar.style.width = `${p}%`;
+      exportProgressBar.textContent = `${p}%`;
+      exportProgressPercent.textContent = `${p}%`;
+    }
+
+    if (status) exportProgressStatus.textContent = status;
+    exportProgressStage.textContent = `Stage ${Math.min(stageIndex, STAGE_TOTAL)}/${STAGE_TOTAL}`;
+  }
+
+  function logProgress(status, type = 'done') {
+    if (!status || status === lastLogLine) return;
+    lastLogLine = status;
+    const row = document.createElement('div');
+    row.className = `log-item ${type}`.trim();
+    row.innerHTML = `<span class="dot"></span><span>${status}</span>`;
+    exportProgressLog.appendChild(row);
+    exportProgressLog.scrollTop = exportProgressLog.scrollHeight;
+  }
+
+  function showError(message) {
+    exportErrorBox.classList.remove('d-none');
+    exportErrorBox.textContent = message;
+    btnRetryExport.classList.remove('d-none');
+  }
+
+  function clearError() {
+    exportErrorBox.classList.add('d-none');
+    exportErrorBox.textContent = '';
+    btnRetryExport.classList.add('d-none');
+  }
+
+  function startElapsedTimer() {
+    if (elapsedTimer) clearInterval(elapsedTimer);
+    exportProgressElapsed.textContent = '0s';
+    elapsedTimer = setInterval(() => {
+      exportProgressElapsed.textContent = `${getElapsedSec()}s`;
+    }, 1000);
+  }
+
+  function stopElapsedTimer() {
+    if (elapsedTimer) clearInterval(elapsedTimer);
+    elapsedTimer = null;
+  }
+
+  function resetProgressPanel() {
+    exportProgressLog.innerHTML = '';
+    lastLogLine = '';
+    stageIndex = 0;
+    exportProgressPanel.classList.remove('d-none');
+    clearError();
+    setProgress(0, 'Preparing export request…');
+  }
+
+  function buildCacheKey({ bbox, want, width, height }) {
+    return JSON.stringify({
+      west: +bbox.getWest().toFixed(5),
+      south: +bbox.getSouth().toFixed(5),
+      east: +bbox.getEast().toFixed(5),
+      north: +bbox.getNorth().toFixed(5),
+      want,
+      width,
+      height
+    });
+  }
+
+  function updateFrameInfo() {
+    const info = frameApi.getFrameInfo();
+    if (!info) {
+      frameInfoEl.textContent = 'Frame inactive (using current viewport)';
+      return;
+    }
+    frameInfoEl.textContent = `W:${info.west.toFixed(4)} E:${info.east.toFixed(4)} S:${info.south.toFixed(4)} N:${info.north.toFixed(4)} · ${info.widthDeg.toFixed(4)}° x ${info.heightDeg.toFixed(4)}°`;
+  }
+
+  function updateExportEstimate() {
+    const { width, height, want } = getSelections();
+    const bbox = frameApi.getActiveBBox();
+    const bboxArea = Math.max(0.00001, (bbox.getEast() - bbox.getWest()) * (bbox.getNorth() - bbox.getSouth()));
+    const pixelMp = (width * height) / 1_000_000;
+    const layerCount = Object.values(want).filter(Boolean).length;
+    const score = bboxArea * 85 + pixelMp * 16 + layerCount * 8;
+
+    if (score < 30) {
+      estimateBadge.className = 'badge text-bg-success';
+      estimateBadge.textContent = 'Fast';
+      estimateText.textContent = `Light export (~${score.toFixed(1)}).`;
+    } else if (score < 75) {
+      estimateBadge.className = 'badge text-bg-warning';
+      estimateBadge.textContent = 'Moderate';
+      estimateText.textContent = `Might take a while (~${score.toFixed(1)}). Consider reducing area or size.`;
+    } else {
+      estimateBadge.className = 'badge text-bg-danger';
+      estimateBadge.textContent = 'Heavy';
+      estimateText.textContent = `High load (~${score.toFixed(1)}). Reduce map extent/output dimensions for better reliability.`;
+    }
+  }
+
   function openPreviewBusy() {
     btnDownloadModal.disabled = true;
     previewBusy.classList.remove('d-none');
@@ -89,6 +228,98 @@ function initPreviewExport(map, frameApi) {
     btnDownloadModal.onclick = () => downloadSVG(svgStr, fileName);
   }
 
+  async function executeExport(options = {}) {
+    if (isExporting) return;
+
+    const btn = document.getElementById('btnExport');
+    const oldHTML = btn.innerHTML;
+
+    isExporting = true;
+    exportAbortController = new AbortController();
+    exportStartedAt = Date.now();
+
+    pageBusy.classList.remove('d-none');
+    btn.disabled = true;
+    btn.innerHTML = '<span class="spinner-border spinner-border-sm me-1" role="status" aria-hidden="true"></span>Exporting…';
+
+    resetProgressPanel();
+    startElapsedTimer();
+
+    try {
+      stageIndex = 1;
+      setProgress(8, 'Reading export options');
+      logProgress('Reading export settings');
+      const { width, height, want, colors } = options.overrideSelections || getSelections();
+      const bbox = frameApi.getActiveBBox();
+      const cacheKey = buildCacheKey({ bbox, want, width, height });
+
+      stageIndex = 2;
+      setProgress(20, 'Fetching data from Overpass', { indeterminate: true });
+
+      let elements = overpassCache.get(cacheKey);
+      if (elements) {
+        logProgress(`Using cached Overpass data (${elements.length} elements)`);
+      } else {
+        logProgress('Requesting OSM features from Overpass API');
+        elements = await fetchElementsForBBox(bbox, want, {
+          signal: exportAbortController.signal,
+          onAttempt: ({ endpoint, index, total }) => {
+            logProgress(`Overpass endpoint ${index + 1}/${total}: ${endpoint}`);
+          }
+        });
+        overpassCache.set(cacheKey, elements);
+        if (overpassCache.size > 5) {
+          const firstKey = overpassCache.keys().next().value;
+          overpassCache.delete(firstKey);
+        }
+      }
+
+      stageIndex = 3;
+      setProgress(35, `Building vector layers from ${elements.length} features`);
+      logProgress(`Fetched ${elements.length} elements`);
+
+      const { svgStr, fileName } = buildSVG({
+        width,
+        height,
+        bbox,
+        elements,
+        want,
+        colors,
+        clipToFrame: frameApi.isFrameActive(),
+        cancelSignal: exportAbortController.signal,
+        onProgress: ({ percent, label }) => {
+          const mapped = 35 + Math.round((percent / 100) * 55);
+          setProgress(mapped, label);
+          logProgress(label);
+        }
+      });
+
+      stageIndex = 4;
+      setProgress(93, 'Preparing download');
+      logProgress('Preparing SVG download');
+      downloadSVG(svgStr, fileName);
+
+      stageIndex = 5;
+      setProgress(100, 'Export completed');
+      logProgress(`Export completed in ${getElapsedSec()}s`);
+
+      lastExportRequest = { width, height, want, colors };
+    } catch (e) {
+      const msg = e && e.message ? e.message : String(e);
+      setProgress(100, msg === 'Export was canceled' ? 'Export canceled' : 'Export failed');
+      logProgress(msg, msg === 'Export was canceled' ? 'warning' : 'error');
+      showError(`Export failed: ${msg}`);
+      lastExportRequest = options.overrideSelections || getSelections();
+    } finally {
+      stopElapsedTimer();
+      pageBusy.classList.add('d-none');
+      btn.disabled = false;
+      btn.innerHTML = oldHTML;
+      exportAbortController = null;
+      isExporting = false;
+    }
+  }
+
   document.getElementById('btnPreview').addEventListener('click', async () => {
     openPreviewBusy();
     try {
@@ -102,7 +333,8 @@ function initPreviewExport(map, frameApi) {
         elements,
         want,
         colors,
-        clipToFrame: frameApi.isFrameActive()
+        clipToFrame: frameApi.isFrameActive(),
+        onProgress: null
       });
       showPreviewSvg(svgStr, fileName);
     } catch (e) {
@@ -110,35 +342,59 @@ function initPreviewExport(map, frameApi) {
     }
   });
 
-  document.getElementById('btnExport').addEventListener('click', async () => {
-    pageBusy.classList.remove('d-none');
-    const btn = document.getElementById('btnExport');
-    const oldHTML = btn.innerHTML;
-    btn.disabled = true;
-    btn.innerHTML = '<span class="spinner-border spinner-border-sm me-1" role="status" aria-hidden="true"></span>Exporting…';
+  document.getElementById('btnExport').addEventListener('click', () => executeExport());
 
-    try {
-      const { width, height, want, colors } = getSelections();
-      const bbox = frameApi.getActiveBBox();
-      const elements = await fetchElementsForBBox(bbox, want);
-      const { svgStr, fileName } = buildSVG({
-        width,
-        height,
-        bbox,
-        elements,
-        want,
-        colors,
-        clipToFrame: frameApi.isFrameActive()
-      });
-      downloadSVG(svgStr, fileName);
-    } catch (e) {
-      alert(`Failed to generate SVG: ${e && e.message ? e.message : e}`);
-    } finally {
-      pageBusy.classList.add('d-none');
-      btn.disabled = false;
-      btn.innerHTML = oldHTML;
-    }
+  btnCancelExport.addEventListener('click', () => {
+    if (!exportAbortController) return;
+    exportAbortController.abort();
+    logProgress('Cancel requested by user', 'warning');
   });
+
+  btnRetryExport.addEventListener('click', () => {
+    if (!lastExportRequest) return;
+    clearError();
+    executeExport({ overrideSelections: lastExportRequest });
+  });
+
+  btnSnapFrame.addEventListener('click', () => {
+    frameApi.snapFrameToViewport();
+    updateFrameInfo();
+    updateExportEstimate();
+  });
+
+  btnResetFrame.addEventListener('click', () => {
+    frameApi.resetFrame();
+    updateFrameInfo();
+    updateExportEstimate();
+  });
+
+  [
+    'w',
+    'h',
+    'chkMajorRoads',
+    'chkMinorRoads',
+    'chkWater',
+    'chkParks',
+    'chkBuildings'
+  ].forEach((id) => {
+    document.getElementById(id).addEventListener('input', updateExportEstimate);
+    document.getElementById(id).addEventListener('change', updateExportEstimate);
+  });
+
+  document.getElementById('btnToggleFrame').addEventListener('click', () => {
+    setTimeout(() => {
+      updateFrameInfo();
+      updateExportEstimate();
+    }, 0);
+  });
+
+  map.on('moveend', () => {
+    updateFrameInfo();
+    updateExportEstimate();
+  });
+
+  updateFrameInfo();
+  updateExportEstimate();
 }
 
 function bootstrapApp() {

--- a/map-exporter/js/overpass.js
+++ b/map-exporter/js/overpass.js
@@ -60,13 +60,32 @@ export function buildOverpassBBox(b, want) {
 out body geom;`;
 }
 
-function timeoutSignal(ms) {
+function timeoutController(ms) {
   const c = new AbortController();
-  setTimeout(() => c.abort(), ms);
-  return c.signal;
+  const timerId = setTimeout(() => c.abort(new Error('Request timeout')), ms);
+  return { controller: c, timerId };
 }
 
-export async function fetchElementsForBBox(bbox, want) {
+function linkAbortSignals(primarySignal, secondarySignal) {
+  if (!primarySignal && !secondarySignal) return { signal: null, cleanup: () => {} };
+  if (!primarySignal) return { signal: secondarySignal, cleanup: () => {} };
+  if (!secondarySignal) return { signal: primarySignal, cleanup: () => {} };
+
+  const c = new AbortController();
+  const onAbort = () => c.abort();
+  primarySignal.addEventListener('abort', onAbort);
+  secondarySignal.addEventListener('abort', onAbort);
+  return {
+    signal: c.signal,
+    cleanup: () => {
+      primarySignal.removeEventListener('abort', onAbort);
+      secondarySignal.removeEventListener('abort', onAbort);
+    }
+  };
+}
+
+export async function fetchElementsForBBox(bbox, want, opts = {}) {
+  const { signal: externalSignal = null, onAttempt = null } = opts;
   const ovp = buildOverpassBBox(bbox, want);
   const endpoints = [
     'https://overpass-api.de/api/interpreter',
@@ -77,13 +96,24 @@ export async function fetchElementsForBBox(bbox, want) {
   let lastErr = null;
   for (let i = 0; i < endpoints.length; i++) {
     const endpoint = endpoints[i];
+    if (externalSignal && externalSignal.aborted) {
+      throw new Error('Export was canceled');
+    }
+    let timerId = null;
+    let cleanup = () => {};
     try {
+      if (onAttempt) onAttempt({ endpoint, index: i, total: endpoints.length });
+      const timeout = timeoutController(120000);
+      timerId = timeout.timerId;
+      const linked = linkAbortSignals(externalSignal, timeout.controller.signal);
+      cleanup = linked.cleanup;
       const resp = await fetch(endpoint, {
         method: 'POST',
         headers: { 'Content-Type': 'application/x-www-form-urlencoded; charset=UTF-8' },
         body: `data=${encodeURIComponent(ovp)}`,
-        signal: timeoutSignal(120000)
+        signal: linked.signal || undefined
       });
+      clearTimeout(timerId);
 
       if (resp.status === 429 || resp.status >= 500) throw new Error(`HTTP ${resp.status}`);
       if (!resp.ok) {
@@ -94,10 +124,16 @@ export async function fetchElementsForBBox(bbox, want) {
       const elements = (await resp.json()).elements || [];
       return elements;
     } catch (e) {
+      if (externalSignal && externalSignal.aborted) {
+        throw new Error('Export was canceled');
+      }
       lastErr = `${endpoint} failed: ${e && e.message ? e.message : e}`;
       if (i < endpoints.length - 1) {
         await new Promise((r) => setTimeout(r, 800 * (i + 1)));
       }
+    } finally {
+      if (timerId) clearTimeout(timerId);
+      cleanup();
     }
   }
 

--- a/map-exporter/js/svg.js
+++ b/map-exporter/js/svg.js
@@ -66,8 +66,16 @@ function relationMultipolygonPath(members, tx, ty) {
   return ordered.map((ring) => polygonPath(ring, tx, ty)).filter(Boolean).join(' ');
 }
 
-export function buildSVG({ width, height, bbox, elements, want, colors, clipToFrame = false }) {
+export function buildSVG({ width, height, bbox, elements, want, colors, clipToFrame = false, onProgress = null, cancelSignal = null }) {
+  const progress = (percent, label) => {
+    if (onProgress) onProgress({ percent, label });
+  };
+  const ensureNotCanceled = () => {
+    if (cancelSignal && cancelSignal.aborted) throw new Error('Export was canceled');
+  };
+
   const { tx, ty, pad, innerW, innerH, west, south, east, north } = buildProjectors(bbox, width, height, 24);
+  progress(30, 'Preparing SVG canvas');
 
   const SVG_NS = 'http://www.w3.org/2000/svg';
   const svg = document.createElementNS(SVG_NS, 'svg');
@@ -114,6 +122,7 @@ export function buildSVG({ width, height, bbox, elements, want, colors, clipToFr
   const watersP = want.water ? elements.filter((e) => predicates.isWaterPolygon(e.tags)) : [];
   const watersL = want.water ? elements.filter((e) => predicates.isWaterLine(e.tags)) : [];
   const buildings = want.buildings ? elements.filter((e) => predicates.isBuilding(e.tags)) : [];
+  progress(40, 'Classifying map features');
 
   const ways = elements.filter((e) => e.type === 'way' && e.geometry && e.geometry.length >= 2);
   const majorRoads = want.majorRoads
@@ -130,8 +139,10 @@ export function buildSVG({ width, height, bbox, elements, want, colors, clipToFr
       || predicates.isLocalRoad(e.tags)
     ))
     : [];
+  progress(50, 'Preparing road layers');
 
-  for (const feat of parks) {
+  for (let i = 0; i < parks.length; i++) {
+    const feat = parks[i];
     const p = document.createElementNS(SVG_NS, 'path');
     if (feat.type === 'way' && feat.geometry) {
       p.setAttribute('d', polygonPath(feat.geometry, tx, ty));
@@ -144,9 +155,12 @@ export function buildSVG({ width, height, bbox, elements, want, colors, clipToFr
     p.setAttribute('fill', colors.parks);
     p.setAttribute('stroke', 'none');
     gParks.appendChild(p);
+    if (i % 1000 === 0) ensureNotCanceled();
   }
+  if (want.parks) progress(60, `Parks layer ready (${parks.length})`);
 
-  for (const feat of watersP) {
+  for (let i = 0; i < watersP.length; i++) {
+    const feat = watersP[i];
     const p = document.createElementNS(SVG_NS, 'path');
     if (feat.type === 'way' && feat.geometry) {
       p.setAttribute('d', polygonPath(feat.geometry, tx, ty));
@@ -160,9 +174,11 @@ export function buildSVG({ width, height, bbox, elements, want, colors, clipToFr
     p.setAttribute('stroke', colors.water);
     p.setAttribute('stroke-width', '0.8');
     gWater.appendChild(p);
+    if (i % 1000 === 0) ensureNotCanceled();
   }
 
-  for (const feat of watersL) {
+  for (let i = 0; i < watersL.length; i++) {
+    const feat = watersL[i];
     if (feat.type !== 'way' || !feat.geometry) continue;
     const d = lineString(feat.geometry, tx, ty);
     if (!d) continue;
@@ -174,10 +190,13 @@ export function buildSVG({ width, height, bbox, elements, want, colors, clipToFr
     p.setAttribute('stroke-linecap', 'round');
     p.setAttribute('stroke-linejoin', 'round');
     gWater.appendChild(p);
+    if (i % 1000 === 0) ensureNotCanceled();
   }
+  if (want.water) progress(70, `Water layer ready (${watersP.length + watersL.length})`);
 
   if (want.buildings) {
-    for (const feat of buildings) {
+    for (let i = 0; i < buildings.length; i++) {
+      const feat = buildings[i];
       const p = document.createElementNS(SVG_NS, 'path');
       if (feat.type === 'way' && feat.geometry) {
         p.setAttribute('d', polygonPath(feat.geometry, tx, ty));
@@ -191,11 +210,14 @@ export function buildSVG({ width, height, bbox, elements, want, colors, clipToFr
       p.setAttribute('stroke', '#fd0000');
       p.setAttribute('stroke-width', '0.4');
       gBldg.appendChild(p);
+      if (i % 1000 === 0) ensureNotCanceled();
     }
+    progress(80, `Buildings layer ready (${buildings.length})`);
   }
 
   const addLine = (collection, g, color, strokeWidth) => {
-    for (const feat of collection) {
+    for (let i = 0; i < collection.length; i++) {
+      const feat = collection[i];
       const d = lineString(feat.geometry, tx, ty);
       if (!d) continue;
       const p = document.createElementNS(SVG_NS, 'path');
@@ -206,6 +228,7 @@ export function buildSVG({ width, height, bbox, elements, want, colors, clipToFr
       p.setAttribute('stroke-linejoin', 'round');
       p.setAttribute('stroke-width', strokeWidth);
       g.appendChild(p);
+      if (i % 1000 === 0) ensureNotCanceled();
     }
   };
 
@@ -214,11 +237,13 @@ export function buildSVG({ width, height, bbox, elements, want, colors, clipToFr
   if (want.buildings) svg.appendChild(gBldg);
   if (want.majorRoads) addLine(majorRoads, gMajorRoads, colors.majorRoads, 2.8), svg.appendChild(gMajorRoads);
   if (want.minorRoads) addLine(minorRoads, gMinorRoads, colors.minorRoads, 1.9), svg.appendChild(gMinorRoads);
+  progress(90, `Road layers ready (${majorRoads.length + minorRoads.length})`);
 
   const serializer = new XMLSerializer();
   const svgStr = serializer.serializeToString(svg);
   const fileName = `map_export_${west.toFixed(4)}_${south.toFixed(4)}_${east.toFixed(4)}_${north.toFixed(4)}_${width}x${height}.svg`
     .replace(/[^\w.\-]+/g, '_');
+  progress(100, 'SVG is ready for download');
 
   return { svgStr, fileName };
 }


### PR DESCRIPTION
### Motivation
- Provide real-time feedback and control for potentially long SVG exports by adding a progress panel, progress log, and cancel/retry actions.
- Expose frame operations (snap/reset/info) so users can control the export area independent of the viewport and get estimates for export workload.
- Improve robustness of Overpass requests with timeouts, retry across endpoints, linked abort signals, and a small in-memory cache to avoid repeated large requests.

### Description
- UI: Added progress panel, progress log, export estimate card, and frame hint card in `map-exporter/index.html` and corresponding CSS styles for `.progress-card`, `.progress-log`, and `.hint-card`.
- Frame controls: Added `setFrameFromBounds`, `snapFrameToViewport`, `resetFrame`, and `getFrameInfo` to `map-exporter/js/frame.js` and exposed them on the frame API so the UI can snap/reset the frame and display frame info via `frameApi`.
- Export flow and UI logic: Implemented `executeExport` with `AbortController`, elapsed timer, stage reporting, progress logging, caching of Overpass responses, cancel/retry buttons, and export estimate updates in `map-exporter/js/main.js`; wired preview/export buttons to the new flow and updated preview behavior.
- Overpass improvements: Reworked timeout handling and signal composition in `map-exporter/js/overpass.js` by adding `timeoutController`, `linkAbortSignals`, support for an external `signal`, endpoint retries with backoff, and `onAttempt` callback for reporting which endpoint is used.
- SVG generation improvements: Extended `buildSVG` in `map-exporter/js/svg.js` to accept `onProgress` and `cancelSignal`, emit progress milestones, check for cancellation during long loops, and report final readiness; updated loops to be cancellable and report partial progress.

### Testing
- No automated tests were added or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e3e6ea6514832ab46abe33a52c6a31)