### PR TITLE
Add per-road-subtype color overrides and wire through export/preview pipeline

### DIFF
--- a/map-exporter/MAX-EXPORTER-ANALYSIS.md
+++ b/map-exporter/MAX-EXPORTER-ANALYSIS.md
@@ -1,0 +1,101 @@
+# max-exporter code analysis
+
+> Note: there is no `max-exporter/` directory in this repository. This analysis is for `map-exporter/`, which is likely what was intended.
+
+## Executive summary
+
+`map-exporter` is a browser-only map-to-SVG export tool built around four modules:
+
+1. `main.js` orchestrates UI, map setup, export workflow, progress, cancellation, retry, and a small in-memory cache.
+2. `overpass.js` builds Overpass QL queries and fetches OSM data with fallback endpoints + timeout + abort support.
+3. `frame.js` manages an optional draggable export frame to constrain the target bounding box.
+4. `svg.js` transforms OSM geometries into layered SVG paths with optional clipping to the active frame.
+
+Overall, the codebase is cleanly modular and practical for medium-size exports. The largest quality concerns are: bbox edge cases around antimeridian/polar regions, potentially expensive client-side processing on very large exports, and a few brittle assumptions around geometry structure.
+
+## Architecture and flow
+
+### 1) App bootstrap and state ownership
+
+`bootstrapApp()` initializes date UI, map, search, frame controls, and export controls. State is mostly closure-scoped in `initPreviewExport()`, which keeps the global surface small and avoids accidental cross-module coupling.
+
+### 2) Export pipeline
+
+The export sequence is:
+
+1. Read options (`getSelections`) and current bbox (`frameApi.getActiveBBox`).
+2. Compute a cache key and attempt cache hit.
+3. Fetch elements from Overpass if needed (`fetchElementsForBBox`).
+4. Build layered SVG (`buildSVG`) while surfacing progress callbacks.
+5. Trigger client-side download (`downloadSVG`).
+
+This is a robust and understandable flow; the stage/progress design gives users confidence during long operations.
+
+### 3) Frame system
+
+`frame.js` overlays a draggable rectangle and two corner handles + one center handle. The implementation is straightforward and updates both map layer and marker positions continuously.
+
+### 4) SVG generation model
+
+`svg.js` projects lon/lat into Web Mercator meters, scales to fit the output canvas with padding, and emits SVG path elements by semantic layer (parks, water, buildings, major roads, minor roads).
+
+It supports relation multipolygons with outer/inner rings and uses `fill-rule="evenodd"` where relevant.
+
+## Strengths
+
+- **Good separation of concerns:** UI orchestration, data fetching, frame control, and rendering are in separate modules.
+- **Operational resilience:** Overpass endpoint fallback and per-request timeout improve reliability.
+- **User experience:** export estimate, stage/progress log, cancel/retry, and preview are meaningful quality-of-life features.
+- **Performance-minded touches:** small LRU-like cache (size 5), progress throttling by stages, and cancellation checks inside long loops.
+
+## Risks and weaknesses
+
+1. **Antimeridian and geographic edge cases**
+   - BBox handling assumes `west <= east` and ordinary latitude ranges; crossing the dateline may produce incorrect area estimation and projection behavior.
+
+2. **Projection robustness near poles**
+   - `lat2y` uses a direct Mercator formula without clamping latitude (typically ±85.05113°), which can blow up near ±90°.
+
+3. **Heavy client-side memory/CPU cost**
+   - Large bbox + high resolution + many features can stress the browser because all filtering and path construction happen in JS on the main thread.
+
+4. **Geometry assumptions**
+   - Several paths expect `way.geometry` or relation member geometry to be well-formed. Nonstandard/incomplete payloads are mostly skipped, but not deeply validated.
+
+5. **Cache key granularity**
+   - Cache key rounds bbox to 5 decimals, which is reasonable, but can cause accidental misses/hits depending on user drag precision and expected determinism.
+
+## Maintainability assessment
+
+- **Readability:** high; naming and structure are clear.
+- **Extensibility:** moderate-to-high; adding a new thematic layer is straightforward in both query and render stages.
+- **Testability:** currently low because modules rely on DOM and browser globals; there is no test harness for pure logic (query generation, projection, layer classification).
+
+## Recommended improvements (priority order)
+
+1. **Harden geographic math**
+   - Clamp latitude before Mercator conversion.
+   - Explicitly guard antimeridian-crossing bbox logic in `frame`/`svg`/estimate code.
+
+2. **Move expensive work off the main thread**
+   - Build SVG in a Web Worker (or chunked microtasks) for better responsiveness on heavy exports.
+
+3. **Add feature-count and node-count guardrails**
+   - Warn or block when estimated element count exceeds safe thresholds.
+
+4. **Improve cache policy**
+   - Keep current behavior, but track rough element weight and evict heaviest/oldest blend instead of strict insertion order.
+
+5. **Add lightweight tests for pure functions**
+   - `buildOverpassBBox`, predicates, and projection helpers can be unit-tested without browser context.
+
+## Quick module-by-module notes
+
+- `main.js`: solid orchestration, good lifecycle handling in `try/catch/finally`.
+- `overpass.js`: strong endpoint fallback design; could expose endpoint metrics for diagnostics.
+- `frame.js`: simple and effective, but bbox normalization should become a shared utility.
+- `svg.js`: good layer output and multipolygon support; needs latitude clamping and optional simplification for large path counts.
+
+## Bottom line
+
+`map-exporter` is a good-quality client-side exporter with thoughtful UX and practical reliability mechanisms. With geospatial edge-case hardening and worker-based rendering, it can become significantly more robust for large or unusual map selections.

--- a/map-exporter/index.html
+++ b/map-exporter/index.html
@@ -293,6 +293,93 @@
                                        value="#000000" title="Minor roads color">
                             </div>
                         </div>
+
+                        <button class="btn btn-outline-secondary btn-sm mb-2"
+                                type="button"
+                                data-bs-toggle="collapse"
+                                data-bs-target="#roadColorOverrides"
+                                aria-expanded="false"
+                                aria-controls="roadColorOverrides">
+                            Advanced road colors
+                        </button>
+
+                        <div class="collapse" id="roadColorOverrides">
+                            <div class="border rounded p-2 bg-light-subtle">
+                                <div class="small fw-semibold mb-1">Major sub-types</div>
+                                <div class="small text-muted mb-2">If unchecked, inherits Major roads color.</div>
+                                <div class="row g-2 align-items-center mb-2">
+                                    <div class="col-7">
+                                        <div class="form-check">
+                                            <input class="form-check-input road-override-toggle" type="checkbox" id="ovrMotorway">
+                                            <label class="form-check-label" for="ovrMotorway">Motorway</label>
+                                        </div>
+                                    </div>
+                                    <div class="col-5 text-end">
+                                        <input id="colMotorway" class="form-control form-control-color color road-override-color" type="color" value="#ff8c00" title="Motorway color" disabled>
+                                    </div>
+                                </div>
+                                <div class="row g-2 align-items-center mb-2">
+                                    <div class="col-7">
+                                        <div class="form-check">
+                                            <input class="form-check-input road-override-toggle" type="checkbox" id="ovrTrunk">
+                                            <label class="form-check-label" for="ovrTrunk">Trunk</label>
+                                        </div>
+                                    </div>
+                                    <div class="col-5 text-end">
+                                        <input id="colTrunk" class="form-control form-control-color color road-override-color" type="color" value="#ff8c00" title="Trunk color" disabled>
+                                    </div>
+                                </div>
+                                <div class="row g-2 align-items-center mb-2">
+                                    <div class="col-7">
+                                        <div class="form-check">
+                                            <input class="form-check-input road-override-toggle" type="checkbox" id="ovrPrimary">
+                                            <label class="form-check-label" for="ovrPrimary">Primary</label>
+                                        </div>
+                                    </div>
+                                    <div class="col-5 text-end">
+                                        <input id="colPrimary" class="form-control form-control-color color road-override-color" type="color" value="#ff8c00" title="Primary color" disabled>
+                                    </div>
+                                </div>
+
+                                <hr class="my-2">
+
+                                <div class="small fw-semibold mb-1">Minor sub-types</div>
+                                <div class="small text-muted mb-2">If unchecked, inherits Minor roads color.</div>
+                                <div class="row g-2 align-items-center mb-2">
+                                    <div class="col-7">
+                                        <div class="form-check">
+                                            <input class="form-check-input road-override-toggle" type="checkbox" id="ovrSecondary">
+                                            <label class="form-check-label" for="ovrSecondary">Secondary</label>
+                                        </div>
+                                    </div>
+                                    <div class="col-5 text-end">
+                                        <input id="colSecondary" class="form-control form-control-color color road-override-color" type="color" value="#000000" title="Secondary color" disabled>
+                                    </div>
+                                </div>
+                                <div class="row g-2 align-items-center mb-2">
+                                    <div class="col-7">
+                                        <div class="form-check">
+                                            <input class="form-check-input road-override-toggle" type="checkbox" id="ovrTertiary">
+                                            <label class="form-check-label" for="ovrTertiary">Tertiary</label>
+                                        </div>
+                                    </div>
+                                    <div class="col-5 text-end">
+                                        <input id="colTertiary" class="form-control form-control-color color road-override-color" type="color" value="#000000" title="Tertiary color" disabled>
+                                    </div>
+                                </div>
+                                <div class="row g-2 align-items-center">
+                                    <div class="col-7">
+                                        <div class="form-check">
+                                            <input class="form-check-input road-override-toggle" type="checkbox" id="ovrLocal">
+                                            <label class="form-check-label" for="ovrLocal">Local (residential, unclassified, service, living street)</label>
+                                        </div>
+                                    </div>
+                                    <div class="col-5 text-end">
+                                        <input id="colLocal" class="form-control form-control-color color road-override-color" type="color" value="#000000" title="Local roads color" disabled>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
                     </div>
 
                     <!-- Non-road layers -->

--- a/map-exporter/js/main.js
+++ b/map-exporter/js/main.js
@@ -31,6 +31,14 @@ function initMap() {
 }
 
 function getSelections() {
+  const majorRoadsColor = document.getElementById('colMajorRoads').value || '#ff8c00';
+  const minorRoadsColor = document.getElementById('colMinorRoads').value || '#000000';
+  const overrideColor = (toggleId, colorId, fallback) => (
+    document.getElementById(toggleId).checked
+      ? (document.getElementById(colorId).value || fallback)
+      : fallback
+  );
+
   return {
     width: Math.max(512, (+document.getElementById('w').value | 0) || 4096),
     height: Math.max(512, (+document.getElementById('h').value | 0) || 4096),
@@ -42,11 +50,19 @@ function getSelections() {
       buildings: document.getElementById('chkBuildings').checked
     },
     colors: {
-      majorRoads: document.getElementById('colMajorRoads').value || '#ff8c00',
-      minorRoads: document.getElementById('colMinorRoads').value || '#000000',
+      majorRoads: majorRoadsColor,
+      minorRoads: minorRoadsColor,
       water: document.getElementById('colWater').value || '#4b64e1',
       parks: document.getElementById('colParks').value || '#00ff32',
       buildings: document.getElementById('colBuildings').value || '#ff2d2d'
+    },
+    roadSubTypeColors: {
+      motorway: overrideColor('ovrMotorway', 'colMotorway', majorRoadsColor),
+      trunk: overrideColor('ovrTrunk', 'colTrunk', majorRoadsColor),
+      primary: overrideColor('ovrPrimary', 'colPrimary', majorRoadsColor),
+      secondary: overrideColor('ovrSecondary', 'colSecondary', minorRoadsColor),
+      tertiary: overrideColor('ovrTertiary', 'colTertiary', minorRoadsColor),
+      local: overrideColor('ovrLocal', 'colLocal', minorRoadsColor)
     }
   };
 }
@@ -249,7 +265,7 @@ function initPreviewExport(map, frameApi) {
       stageIndex = 1;
       setProgress(8, 'Reading export options');
       logProgress('Reading export settings');
-      const { width, height, want, colors } = options.overrideSelections || getSelections();
+      const { width, height, want, colors, roadSubTypeColors } = options.overrideSelections || getSelections();
       const bbox = frameApi.getActiveBBox();
       const cacheKey = buildCacheKey({ bbox, want, width, height });
 
@@ -285,6 +301,7 @@ function initPreviewExport(map, frameApi) {
         elements,
         want,
         colors,
+        roadSubTypeColors,
         clipToFrame: frameApi.isFrameActive(),
         cancelSignal: exportAbortController.signal,
         onProgress: ({ percent, label }) => {
@@ -323,7 +340,7 @@ function initPreviewExport(map, frameApi) {
   document.getElementById('btnPreview').addEventListener('click', async () => {
     openPreviewBusy();
     try {
-      const { width, height, want, colors } = getSelections();
+      const { width, height, want, colors, roadSubTypeColors } = getSelections();
       const bbox = frameApi.getActiveBBox();
       const elements = await fetchElementsForBBox(bbox, want);
       const { svgStr, fileName } = buildSVG({
@@ -333,6 +350,7 @@ function initPreviewExport(map, frameApi) {
         elements,
         want,
         colors,
+        roadSubTypeColors,
         clipToFrame: frameApi.isFrameActive(),
         onProgress: null
       });
@@ -379,6 +397,26 @@ function initPreviewExport(map, frameApi) {
   ].forEach((id) => {
     document.getElementById(id).addEventListener('input', updateExportEstimate);
     document.getElementById(id).addEventListener('change', updateExportEstimate);
+  });
+
+  const overridePairs = [
+    ['ovrMotorway', 'colMotorway'],
+    ['ovrTrunk', 'colTrunk'],
+    ['ovrPrimary', 'colPrimary'],
+    ['ovrSecondary', 'colSecondary'],
+    ['ovrTertiary', 'colTertiary'],
+    ['ovrLocal', 'colLocal']
+  ];
+  overridePairs.forEach(([toggleId, colorId]) => {
+    const toggleEl = document.getElementById(toggleId);
+    const colorEl = document.getElementById(colorId);
+    const syncState = () => {
+      colorEl.disabled = !toggleEl.checked;
+      updateExportEstimate();
+    };
+    toggleEl.addEventListener('change', syncState);
+    colorEl.addEventListener('input', updateExportEstimate);
+    syncState();
   });
 
   document.getElementById('btnToggleFrame').addEventListener('click', () => {

--- a/map-exporter/js/svg.js
+++ b/map-exporter/js/svg.js
@@ -66,7 +66,18 @@ function relationMultipolygonPath(members, tx, ty) {
   return ordered.map((ring) => polygonPath(ring, tx, ty)).filter(Boolean).join(' ');
 }
 
-export function buildSVG({ width, height, bbox, elements, want, colors, clipToFrame = false, onProgress = null, cancelSignal = null }) {
+export function buildSVG({
+  width,
+  height,
+  bbox,
+  elements,
+  want,
+  colors,
+  roadSubTypeColors = {},
+  clipToFrame = false,
+  onProgress = null,
+  cancelSignal = null
+}) {
   const progress = (percent, label) => {
     if (onProgress) onProgress({ percent, label });
   };
@@ -140,6 +151,17 @@ export function buildSVG({ width, height, bbox, elements, want, colors, clipToFr
     ))
     : [];
   progress(50, 'Preparing road layers');
+
+  const roadColorForFeature = (feat) => {
+    const roadType = feat.tags?.highway || '';
+    if (roadType === 'motorway') return roadSubTypeColors.motorway || colors.majorRoads;
+    if (roadType === 'trunk') return roadSubTypeColors.trunk || colors.majorRoads;
+    if (roadType === 'primary') return roadSubTypeColors.primary || colors.majorRoads;
+    if (roadType === 'secondary') return roadSubTypeColors.secondary || colors.minorRoads;
+    if (roadType === 'tertiary') return roadSubTypeColors.tertiary || colors.minorRoads;
+    if (predicates.isLocalRoad(feat.tags)) return roadSubTypeColors.local || colors.minorRoads;
+    return colors.minorRoads;
+  };
 
   for (let i = 0; i < parks.length; i++) {
     const feat = parks[i];
@@ -215,7 +237,7 @@ export function buildSVG({ width, height, bbox, elements, want, colors, clipToFr
     progress(80, `Buildings layer ready (${buildings.length})`);
   }
 
-  const addLine = (collection, g, color, strokeWidth) => {
+  const addLine = (collection, g, strokeWidth) => {
     for (let i = 0; i < collection.length; i++) {
       const feat = collection[i];
       const d = lineString(feat.geometry, tx, ty);
@@ -223,7 +245,7 @@ export function buildSVG({ width, height, bbox, elements, want, colors, clipToFr
       const p = document.createElementNS(SVG_NS, 'path');
       p.setAttribute('d', d);
       p.setAttribute('fill', 'none');
-      p.setAttribute('stroke', color);
+      p.setAttribute('stroke', roadColorForFeature(feat));
       p.setAttribute('stroke-linecap', 'round');
       p.setAttribute('stroke-linejoin', 'round');
       p.setAttribute('stroke-width', strokeWidth);
@@ -235,8 +257,8 @@ export function buildSVG({ width, height, bbox, elements, want, colors, clipToFr
   if (want.parks) svg.appendChild(gParks);
   if (want.water) svg.appendChild(gWater);
   if (want.buildings) svg.appendChild(gBldg);
-  if (want.majorRoads) addLine(majorRoads, gMajorRoads, colors.majorRoads, 2.8), svg.appendChild(gMajorRoads);
-  if (want.minorRoads) addLine(minorRoads, gMinorRoads, colors.minorRoads, 1.9), svg.appendChild(gMinorRoads);
+  if (want.majorRoads) addLine(majorRoads, gMajorRoads, 2.8), svg.appendChild(gMajorRoads);
+  if (want.minorRoads) addLine(minorRoads, gMinorRoads, 1.9), svg.appendChild(gMinorRoads);
   progress(90, `Road layers ready (${majorRoads.length + minorRoads.length})`);
 
   const serializer = new XMLSerializer();


### PR DESCRIPTION
### Motivation

- Provide finer styling control by allowing users to override colors for specific road subtypes (motorway, trunk, primary, secondary, tertiary, local) in addition to global major/minor road colors.
- Surface the new controls in the UI and propagate selections into the preview and final SVG export so outputs reflect subtype overrides.
- Add a static code analysis document `MAX-EXPORTER-ANALYSIS.md` summarizing code structure and recommended improvements.

### Description

- Add an expandable "Advanced road colors" panel in `map-exporter/index.html` with per-subtype toggle+color inputs for major and minor road categories.
- Extend `getSelections()` in `map-exporter/js/main.js` to collect `roadSubTypeColors` and add UI wiring to enable/disable subtype color inputs and trigger re-estimates via `overridePairs` event handlers.
- Pass `roadSubTypeColors` through the preview and export flows by updating callers of `buildSVG` to include the new parameter and destructuring it where needed.
- Update `map-exporter/js/svg.js` to accept `roadSubTypeColors`, add `roadColorForFeature()` to choose the appropriate stroke color per feature, and apply that color when building road `path` elements.
- Add `MAX-EXPORTER-ANALYSIS.md` as a new file with a high-level analysis, risks, and recommendations for the `map-exporter` codebase.

### Testing

- No automated test suite was present for this codebase, so no automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e67636cbdc832a92cd4f216c9298e1)