### PR TITLE
Add optional waterway centerlines export and UI toggle for water areas

### DIFF
--- a/map-exporter/index.html
+++ b/map-exporter/index.html
@@ -403,7 +403,11 @@
                         <div class="col-7">
                             <div class="form-check">
                                 <input class="form-check-input" type="checkbox" id="chkWater" checked>
-                                <label class="form-check-label" for="chkWater">Water</label>
+                                <label class="form-check-label" for="chkWater">Water areas</label>
+                            </div>
+                            <div class="form-check ms-3 mt-1">
+                                <input class="form-check-input" type="checkbox" id="chkWaterLines">
+                                <label class="form-check-label small text-muted" for="chkWaterLines">Include river/stream centerlines</label>
                             </div>
                         </div>
                         <div class="col-5 text-end">

--- a/map-exporter/js/main.js
+++ b/map-exporter/js/main.js
@@ -46,6 +46,7 @@ function getSelections() {
       majorRoads: document.getElementById('chkMajorRoads').checked,
       minorRoads: document.getElementById('chkMinorRoads').checked,
       water: document.getElementById('chkWater').checked,
+      waterLines: document.getElementById('chkWater').checked && document.getElementById('chkWaterLines').checked,
       parks: document.getElementById('chkParks').checked,
       buildings: document.getElementById('chkBuildings').checked
     },
@@ -320,7 +321,7 @@ function initPreviewExport(map, frameApi) {
       setProgress(100, 'Export completed');
       logProgress(`Export completed in ${getElapsedSec()}s`);
 
-      lastExportRequest = { width, height, want, colors };
+      lastExportRequest = { width, height, want, colors, roadSubTypeColors };
     } catch (e) {
       const msg = e && e.message ? e.message : String(e);
       setProgress(100, msg === 'Export was canceled' ? 'Export canceled' : 'Export failed');
@@ -392,12 +393,21 @@ function initPreviewExport(map, frameApi) {
     'chkMajorRoads',
     'chkMinorRoads',
     'chkWater',
+    'chkWaterLines',
     'chkParks',
     'chkBuildings'
   ].forEach((id) => {
     document.getElementById(id).addEventListener('input', updateExportEstimate);
     document.getElementById(id).addEventListener('change', updateExportEstimate);
   });
+
+  const waterToggle = document.getElementById('chkWater');
+  const waterLinesToggle = document.getElementById('chkWaterLines');
+  const syncWaterLineToggle = () => {
+    waterLinesToggle.disabled = !waterToggle.checked;
+  };
+  waterToggle.addEventListener('change', syncWaterLineToggle);
+  syncWaterLineToggle();
 
   const overridePairs = [
     ['ovrMotorway', 'colMotorway'],

--- a/map-exporter/js/overpass.js
+++ b/map-exporter/js/overpass.js
@@ -30,9 +30,12 @@ export function buildOverpassBBox(b, want) {
       `way["natural"="water"](${south},${west},${north},${east});`,
       `relation["natural"="water"](${south},${west},${north},${east});`,
       `way["waterway"="riverbank"](${south},${west},${north},${east});`,
-      `relation["waterway"="riverbank"](${south},${west},${north},${east});`,
-      `way["waterway"~"^(river|stream|canal)$"](${south},${west},${north},${east});`
+      `relation["waterway"="riverbank"](${south},${west},${north},${east});`
     );
+  }
+
+  if (want.waterLines) {
+    parts.push(`way["waterway"~"^(river|stream|canal)$"](${south},${west},${north},${east});`);
   }
 
   if (want.buildings) {
@@ -50,6 +53,8 @@ export function buildOverpassBBox(b, want) {
     const roadRegex = `^(${Array.from(new Set(roadClasses)).join('|')})$`;
     parts.push(`way["highway"~"${roadRegex}"](${south},${west},${north},${east});`);
   }
+
+  if (!parts.length) return '';
 
   const body = parts.join('\n  ');
   return `
@@ -87,6 +92,8 @@ function linkAbortSignals(primarySignal, secondarySignal) {
 export async function fetchElementsForBBox(bbox, want, opts = {}) {
   const { signal: externalSignal = null, onAttempt = null } = opts;
   const ovp = buildOverpassBBox(bbox, want);
+  if (!ovp) return [];
+
   const endpoints = [
     'https://overpass-api.de/api/interpreter',
     'https://overpass.kumi.systems/api/interpreter',

--- a/map-exporter/js/svg.js
+++ b/map-exporter/js/svg.js
@@ -39,16 +39,17 @@ function lineString(coords, tx, ty) {
   return d;
 }
 
-function polygonPath(geom, tx, ty) {
+function polygonPath(geom, tx, ty, options = {}) {
   if (!geom || !geom.length) return '';
   const first = geom[0];
   const last = geom[geom.length - 1];
   let d = lineString(geom, tx, ty);
-  if (first && last && first.lat === last.lat && first.lon === last.lon) d += 'Z';
+  const isClosed = first && last && first.lat === last.lat && first.lon === last.lon;
+  if (isClosed || options.forceClose) d += 'Z';
   return d;
 }
 
-function relationMultipolygonPath(members, tx, ty) {
+function relationMultipolygonPath(members, tx, ty, options = {}) {
   if (!members || !members.length) return '';
 
   const outers = [];
@@ -63,7 +64,7 @@ function relationMultipolygonPath(members, tx, ty) {
   }
 
   const ordered = [...outers, ...unknown, ...inners];
-  return ordered.map((ring) => polygonPath(ring, tx, ty)).filter(Boolean).join(' ');
+  return ordered.map((ring) => polygonPath(ring, tx, ty, options)).filter(Boolean).join(' ');
 }
 
 export function buildSVG({
@@ -131,7 +132,7 @@ export function buildSVG({
 
   const parks = want.parks ? elements.filter((e) => predicates.isPark(e.tags)) : [];
   const watersP = want.water ? elements.filter((e) => predicates.isWaterPolygon(e.tags)) : [];
-  const watersL = want.water ? elements.filter((e) => predicates.isWaterLine(e.tags)) : [];
+  const watersL = want.waterLines ? elements.filter((e) => predicates.isWaterLine(e.tags)) : [];
   const buildings = want.buildings ? elements.filter((e) => predicates.isBuilding(e.tags)) : [];
   progress(40, 'Classifying map features');
 
@@ -185,9 +186,9 @@ export function buildSVG({
     const feat = watersP[i];
     const p = document.createElementNS(SVG_NS, 'path');
     if (feat.type === 'way' && feat.geometry) {
-      p.setAttribute('d', polygonPath(feat.geometry, tx, ty));
+      p.setAttribute('d', polygonPath(feat.geometry, tx, ty, { forceClose: true }));
     } else if (feat.type === 'relation' && feat.members) {
-      const d = relationMultipolygonPath(feat.members, tx, ty);
+      const d = relationMultipolygonPath(feat.members, tx, ty, { forceClose: true });
       if (!d) continue;
       p.setAttribute('d', d);
       p.setAttribute('fill-rule', 'evenodd');
@@ -214,7 +215,7 @@ export function buildSVG({
     gWater.appendChild(p);
     if (i % 1000 === 0) ensureNotCanceled();
   }
-  if (want.water) progress(70, `Water layer ready (${watersP.length + watersL.length})`);
+  if (want.water || want.waterLines) progress(70, `Water layer ready (${watersP.length + watersL.length})`);
 
   if (want.buildings) {
     for (let i = 0; i < buildings.length; i++) {
@@ -255,7 +256,7 @@ export function buildSVG({
   };
 
   if (want.parks) svg.appendChild(gParks);
-  if (want.water) svg.appendChild(gWater);
+  if (want.water || want.waterLines) svg.appendChild(gWater);
   if (want.buildings) svg.appendChild(gBldg);
   if (want.majorRoads) addLine(majorRoads, gMajorRoads, 2.8), svg.appendChild(gMajorRoads);
   if (want.minorRoads) addLine(minorRoads, gMinorRoads, 1.9), svg.appendChild(gMinorRoads);


### PR DESCRIPTION
### Motivation

- Provide an option to include river/stream/canal centerlines separately from water area polygons so users can export linear water features when desired.
- Keep Overpass requests minimal and avoid queries when no layers are selected.
- Ensure water polygons are closed correctly when rendering SVG to avoid rendering artifacts.

### Description

- UI: rename the water label to `Water areas` and add a new checkbox `chkWaterLines` for "Include river/stream centerlines" in `map-exporter/index.html`.
- Selections & UI state: include `waterLines` in `getSelections()` and wire `chkWaterLines` into the event listeners and disabled state syncing in `map-exporter/js/main.js`, and include `roadSubTypeColors` in the last export request bookkeeping.
- Overpass query: only add `waterway` (river/stream/canal) way predicates when `want.waterLines` is true, return early with an empty query string if no predicates were selected, and make `fetchElementsForBBox()` return `[]` when there's nothing to request in `map-exporter/js/overpass.js`.
- SVG generation: add `forceClose` option to `polygonPath` and propagate it through `relationMultipolygonPath`, force-close water polygons, only include water lines when `want.waterLines` is set, and treat the water layer as present when either water areas or water lines are requested in `map-exporter/js/svg.js`.

### Testing

- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a19d83d9b10832aba620470451e97e1)