### PR TITLE
Add optional railways layer to map exporter

### DIFF
--- a/map-exporter/index.html
+++ b/map-exporter/index.html
@@ -416,6 +416,19 @@
                         </div>
                     </div>
 
+                    <div class="row g-2 align-items-center mb-2">
+                        <div class="col-7">
+                            <div class="form-check">
+                                <input class="form-check-input" type="checkbox" id="chkRailways" checked>
+                                <label class="form-check-label" for="chkRailways">Train rails</label>
+                            </div>
+                        </div>
+                        <div class="col-5 text-end">
+                            <input id="colRailways" class="form-control form-control-color color" type="color" value="#6f42c1"
+                                   title="Train rails color">
+                        </div>
+                    </div>
+
                     <div class="row g-2 align-items-center">
                         <div class="col-7">
                             <div class="form-check">

--- a/map-exporter/js/main.js
+++ b/map-exporter/js/main.js
@@ -48,14 +48,16 @@ function getSelections() {
       water: document.getElementById('chkWater').checked,
       waterLines: document.getElementById('chkWater').checked && document.getElementById('chkWaterLines').checked,
       parks: document.getElementById('chkParks').checked,
-      buildings: document.getElementById('chkBuildings').checked
+      buildings: document.getElementById('chkBuildings').checked,
+      railways: document.getElementById('chkRailways').checked
     },
     colors: {
       majorRoads: majorRoadsColor,
       minorRoads: minorRoadsColor,
       water: document.getElementById('colWater').value || '#4b64e1',
       parks: document.getElementById('colParks').value || '#00ff32',
-      buildings: document.getElementById('colBuildings').value || '#ff2d2d'
+      buildings: document.getElementById('colBuildings').value || '#ff2d2d',
+      railways: document.getElementById('colRailways').value || '#6f42c1'
     },
     roadSubTypeColors: {
       motorway: overrideColor('ovrMotorway', 'colMotorway', majorRoadsColor),
@@ -395,7 +397,8 @@ function initPreviewExport(map, frameApi) {
     'chkWater',
     'chkWaterLines',
     'chkParks',
-    'chkBuildings'
+    'chkBuildings',
+    'chkRailways'
   ].forEach((id) => {
     document.getElementById(id).addEventListener('input', updateExportEstimate);
     document.getElementById(id).addEventListener('change', updateExportEstimate);

--- a/map-exporter/js/overpass.js
+++ b/map-exporter/js/overpass.js
@@ -4,7 +4,8 @@ export const predicates = {
   isWaterLine: (t) => t && /^(river|stream|canal)$/.test(t.waterway || ''),
   highwayEq: (t, val) => t && t.highway === val,
   isLocalRoad: (t) => t && /^(residential|unclassified|service|living_street)$/.test(t.highway || ''),
-  isBuilding: (t) => t && !!t.building
+  isBuilding: (t) => t && !!t.building,
+  isRailway: (t) => t && t.railway === 'rail'
 };
 
 export function buildOverpassBBox(b, want) {
@@ -43,6 +44,10 @@ export function buildOverpassBBox(b, want) {
       `way["building"](${south},${west},${north},${east});`,
       `relation["building"](${south},${west},${north},${east});`
     );
+  }
+
+  if (want.railways) {
+    parts.push(`way["railway"="rail"](${south},${west},${north},${east});`);
   }
 
   const roadClasses = [];

--- a/map-exporter/js/svg.js
+++ b/map-exporter/js/svg.js
@@ -129,11 +129,15 @@ export function buildSVG({
   const gBldg = group(); gBldg.setAttribute('id', 'buildings');
   const gMajorRoads = group(); gMajorRoads.setAttribute('id', 'major_roads');
   const gMinorRoads = group(); gMinorRoads.setAttribute('id', 'minor_roads');
+  const gRailways = group(); gRailways.setAttribute('id', 'railways');
 
   const parks = want.parks ? elements.filter((e) => predicates.isPark(e.tags)) : [];
   const watersP = want.water ? elements.filter((e) => predicates.isWaterPolygon(e.tags)) : [];
   const watersL = want.waterLines ? elements.filter((e) => predicates.isWaterLine(e.tags)) : [];
   const buildings = want.buildings ? elements.filter((e) => predicates.isBuilding(e.tags)) : [];
+  const railways = want.railways
+    ? elements.filter((e) => e.type === 'way' && e.geometry && e.geometry.length >= 2 && predicates.isRailway(e.tags))
+    : [];
   progress(40, 'Classifying map features');
 
   const ways = elements.filter((e) => e.type === 'way' && e.geometry && e.geometry.length >= 2);
@@ -260,7 +264,24 @@ export function buildSVG({
   if (want.buildings) svg.appendChild(gBldg);
   if (want.majorRoads) addLine(majorRoads, gMajorRoads, 2.8), svg.appendChild(gMajorRoads);
   if (want.minorRoads) addLine(minorRoads, gMinorRoads, 1.9), svg.appendChild(gMinorRoads);
-  progress(90, `Road layers ready (${majorRoads.length + minorRoads.length})`);
+  if (want.railways) {
+    for (let i = 0; i < railways.length; i++) {
+      const feat = railways[i];
+      const d = lineString(feat.geometry, tx, ty);
+      if (!d) continue;
+      const p = document.createElementNS(SVG_NS, 'path');
+      p.setAttribute('d', d);
+      p.setAttribute('fill', 'none');
+      p.setAttribute('stroke', colors.railways);
+      p.setAttribute('stroke-linecap', 'round');
+      p.setAttribute('stroke-linejoin', 'round');
+      p.setAttribute('stroke-width', '2.2');
+      gRailways.appendChild(p);
+      if (i % 1000 === 0) ensureNotCanceled();
+    }
+    svg.appendChild(gRailways);
+  }
+  progress(90, `Transport layers ready (${majorRoads.length + minorRoads.length + railways.length})`);
 
   const serializer = new XMLSerializer();
   const svgStr = serializer.serializeToString(svg);


### PR DESCRIPTION
### Motivation
- Provide an option to include train rails in exports so users can toggle visibility and color of railway lines in generated SVG maps.

### Description
- Added UI controls for `chkRailways` and `colRailways` in `map-exporter/index.html` to toggle railways and choose their color.
- Extended `getSelections` in `map-exporter/js/main.js` to include `railways` in the `want` and `colors` objects and to wire the new checkbox into the export estimate update listeners.
- Added `isRailway` predicate and included railway ways in the Overpass bbox query in `map-exporter/js/overpass.js` when `want.railways` is true.
- Implemented railway rendering in `map-exporter/js/svg.js` by creating a `gRailways` group, filtering railway ways, drawing them as stroked paths using `colors.railways`, and including them in the progress summary.

### Testing
- No automated tests were added or executed for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a25774bbe58832aa607c7c1b6fc99e0)